### PR TITLE
Sort configurable Attributes by position

### DIFF
--- a/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Product/Configurable.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Product/Configurable.php
@@ -228,6 +228,7 @@ class Configurable
                 ]
             )
             ->group('product_id')
+            ->order('position ASC')
             ->where('product_id IN (?)', $productIds);
         $this->dbHelper->addGroupConcatColumn($select, 'attribute_ids', 'attribute_id');
 


### PR DESCRIPTION
Hi,

currently the configurable Attributes are not explicitly ordered. By applying an order to the underlying sql it should be then fixed.

Thanks and Greetings!
\- Thomas