### PR TITLE
Switch from OR-logic to AND-logic

### DIFF
--- a/src/module-vsbridge-indexer-catalog/Model/ResourceModel/AttributeMetadata.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ResourceModel/AttributeMetadata.php
@@ -252,16 +252,9 @@ class AttributeMetadata
     {
         /** @var Collection $collection */
         $collection = $this->collectionFactory->create();
-        $collection->addFieldToFilter(
-            [
-                'is_visible',
-                'is_visible_on_front',
-            ],
-            [
-                ['eq' => 1],
-                ['eq' => 1],
-            ]
-        );
+        $collection
+          ->addFieldToFilter('is_visible', ['eq' => 1])
+          ->addFieldToFilter('is_visible_on_front', ['eq' => 1]);
 
         return $collection->getSelect();
     }


### PR DESCRIPTION
closes #383

When collecting attributes to populate `attributes_metadata` almost ALL attributes were fetched creating a lot of data to be transferred to ElasticSearch. I changed the the logic so only the attributes that have `is_visible` AND `is_visible_on_front` set will be collected.
I assume this was intent from the beginning.

Probably we can even get rid of the `is_visible` check and only fetch attributes based on `is_visible_on_front`. 
I think an attribute will never have `is_visible == 0` and `is_visible_on_front == 1` at the same time?!
What do you think @afirlejczyk @doliwa-divante ?